### PR TITLE
Align Search Bar Component

### DIFF
--- a/components/Header/Header.module.css
+++ b/components/Header/Header.module.css
@@ -26,7 +26,7 @@
 
 .searchBarWrap {
   grid-area: searchBarWrap;
-  margin: 0;
+  margin: 0 auto;
   width: 100%;
   font-size: 1.3em;
   margin-bottom: 1em;
@@ -97,7 +97,6 @@
 
   .searchBarWrap {
     max-width: 65%;
-    margin: 0;
     position: relative;
   }
 

--- a/components/SearchBar/SearchBar.module.css
+++ b/components/SearchBar/SearchBar.module.css
@@ -12,6 +12,7 @@
   box-shadow: 0 2px 3px rgba(0, 0, 0, 0.06);
   border: 1px solid var(--lighterGrey);
   font-size: 18px;
+  margin-top: 5px;
 }
 
 .inputBig {
@@ -28,7 +29,7 @@
 .button {
   position: absolute;
   right: 20px;
-  bottom: 20%;
+  top: 50%;
   background: #fff;
   border: 0;
   margin-bottom: 0;


### PR DESCRIPTION
- Small styling tweaks to center align and space the Search Bar Component better.



## Description
Small styling tweaks to align the search bar in the centre and make better use of white space. Reduce margin on the top input to better vertically align the item.

Before ( Live ):
![image](https://user-images.githubusercontent.com/11334905/118358371-60384180-b576-11eb-846c-9d9b2a3ba226.png)

After ( Storybook view ):
![image](https://user-images.githubusercontent.com/11334905/118358385-70502100-b576-11eb-82bf-5329955c6396.png)



#### Impacted Areas in Application
Header css
Searchbar css


#### Steps to Test or Reproduce
View Searchbar.

------------------------------------------------
## PR Checklist:

- [x] My code follows the style guidelines of this project and I have double check my own code
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
  NO: CSS styling change, no functionality.
- [x] I have run `npm run test` and be sure all test pass
  NO: I have run test, previous failing tests are obviously still failing
- [x] I have run `npm run build:dev` and be sure no error block the build
- [x] I have test locally that everything run as expected
- [x] I have properly fill in the PR template
- [x] I have ask for reviews
