### PR TITLE
Fix: pass userIp to api

### DIFF
--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -63,52 +63,6 @@ const SearchBar = ({ big }: SearchProps) => {
   }, [query])
 
   useEffect(() => {
-    const handleKeyDown = (event) => {
-      const { key } = event
-
-      switch (key) {
-        case 'ArrowUp':
-          event.preventDefault()
-          setSearchSuggestedWords(false)
-          return setHighlightIndex((prevIndex: number) => {
-            if (prevIndex === 0) {
-              return prevIndex
-            } else {
-              return prevIndex - 1
-            }
-          })
-
-        case 'ArrowDown':
-          setSearchSuggestedWords(false)
-          return setHighlightIndex((prevIndex: number) => {
-            if (prevIndex === null) {
-              return 0
-            }
-
-            if (prevIndex === suggestedWords.length - 1) {
-              return prevIndex
-            } else {
-              return prevIndex + 1
-            }
-          })
-
-        case 'Escape':
-          setIsSuggestionOpen(false)
-          break
-
-        default:
-          setHighlightIndex(null)
-        // setSearchValue(event.target.defaultValue)
-      }
-    }
-    document.body.addEventListener('keydown', handleKeyDown)
-
-    return () => {
-      document.body.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [searchValue])
-
-  useEffect(() => {
     const fetchSuggestedWords = async () => {
       try {
         const res = await fetchJsonp(`${SUGGESTED_WORDS_URL}${searchValue}`)
@@ -123,7 +77,52 @@ const SearchBar = ({ big }: SearchProps) => {
     if (searchSuggestedWords) {
       fetchSuggestedWords()
     }
+
+    document.body.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.body.removeEventListener('keydown', handleKeyDown)
+    }
   }, [searchValue])
+
+  const handleKeyDown = (event) => {
+    const { key } = event
+
+    switch (key) {
+      case 'ArrowUp':
+        event.preventDefault()
+        setSearchSuggestedWords(false)
+        return setHighlightIndex((prevIndex: number) => {
+          if (prevIndex === 0) {
+            return prevIndex
+          } else {
+            return prevIndex - 1
+          }
+        })
+
+      case 'ArrowDown':
+        setSearchSuggestedWords(false)
+        return setHighlightIndex((prevIndex: number) => {
+          if (prevIndex === null) {
+            return 0
+          }
+
+          if (prevIndex === suggestedWords.length - 1) {
+            return prevIndex
+          } else {
+            return prevIndex + 1
+          }
+        })
+
+      case 'Escape':
+        setIsSuggestionOpen(false)
+        break
+
+      default:
+        setHighlightIndex(null)
+      // setSearchValue(event.target.defaultValue)
+    }
+  }
 
   function onSubmit() {
     search(searchValue)

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -451,15 +451,19 @@ SearchPage.getInitialProps = async ({ req, res, query }) => {
       return Router.push('/')
     }
   }
-  let statusCode = res ? res.statusCode : null
 
+  let statusCode = res ? res.statusCode : null
   const queryNoWhite = queryNoWitheSpace(searchQuery)
   let results: resultsObj = null
   let activeTab = findTabByType(type)
-
   let userAgent
   let adultContentCookie
+  let ipClient
+
   if (req) {
+    ipClient = req.headers['x-real-ip'] || req.connection.remoteAddress
+    console.log({ ipClient })
+
     userAgent = req.headers['user-agent']
     adultContentCookie = isNaN(Number(req.cookies[COOKIE_NAME_ADULT_FILTER]))
       ? 1
@@ -478,14 +482,9 @@ SearchPage.getInitialProps = async ({ req, res, query }) => {
           new URLSearchParams({
             query: `${queryNoWhite}`,
             AdultContentFilter: adultContentCookie,
-          }),
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            'User-Agent': userAgent,
-            'Access-Control-Allow-Headers': '*',
-          },
-        }
+            UserIp: ipClient,
+            UserAgent: userAgent,
+          })
       )
 
       if (data.ok) {


### PR DESCRIPTION
## Description
To display results with geolocalization, we need to send user Ip address to the Bing API.
EfW API take care of it, getting this IP address either from API call Params or from Http Context.

Currently we don't send anything, which means the UserIp is undefined. 
Efw API interpreter this as wrong and fallback to server region, which is UK.

In the case of client-side request is not a problem since no UserIp params is sent at all and it 

- pass UserIp as param to API
- Clean up UserAgent header and pass just UserAgent param
- Cean up SearchBar useEffect

#### Impacted Areas in Application
List general components of the application that this PR will affect:


#### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.


#### Related PRs
If you PR is related to other part of PR, list them here

------------------------------------------------
## PR Checklist:

- [ ] My code follows the style guidelines of this project and I have double check my own code
- [ ] I have made corresponding changes to the documentation, if any
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run test` and be sure all test pass
- [ ] I have run `npm run build:dev` and be sure no error blovk the build
- [ ] I have test locally that everything run as expected
- [ ] I have properly fill in the PR template
- [ ] I have ask for reviews
