### PR TITLE
Fix: Overlap between menu and drop tooltip (issue 83)

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -17,7 +17,6 @@ function Droplet() {
   return (
     <div
       className={styles.dropletContainer}
-      onMouseEnter={() => setHideTooltip(false)}
       onMouseLeave={() => setHideTooltip(true)}
       onClick={() => setHideTooltip((prev) => !prev)}
     >


### PR DESCRIPTION
### Related Issue
https://github.com/ElliotForWater/elliotforwater.com/issues/83

## Description
Previously, the drop tooltip was opening on mouseover which created a strange overlap if the hamburger menu was also open. 

Now, the the drop tooltip only opens on click. It also closes on mouseLeave and on click (if open). This means if the user has opened the menu on the home page, the click required to open the drop menu  immediately closes the settings menu. Keeping the drop tooltip close functionality on close ensures the tooltip will not be open when the user starts interacting with the menu.

#### Impacted Areas in Application
This only impacts the tooltip/menu interaction bug.

#### Steps to Test or Reproduce
Open both the drop tooltip and the menu alternately. There are no cases where overlap occurs and the interaction still feels natural.

#### Related PRs
None

------------------------------------------------
## PR Checklist:

- [x] My code follows the style guidelines of this project and I have double check my own code
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run test` and be sure all test pass
- [x] I have run `npm run build:dev` and be sure no error blovk the build
- [x] I have test locally that everything run as expected
- [x] I have properly fill in the PR template
- [x] I have ask for reviews
