### PR TITLE
fix: searching for an empty string returns an error

### DIFF
--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -138,7 +138,7 @@ const SearchBar = ({ big }: SearchProps) => {
   }
 
   function search(searchString: string, event?) {
-    if (!searchString) {
+    if (!searchString || !/\S/.test(searchString)) {
       return
     }
 
@@ -179,10 +179,11 @@ const SearchBar = ({ big }: SearchProps) => {
               autoComplete='off'
               autoCorrect='off'
               spellCheck='false'
+              id='search-form'
               placeholder={t('common:search_input')}
               register={register}
             />
-            <button className={big ? styles.buttonBig : styles.button} type='submit'>
+            <button className={big ? styles.buttonBig : styles.button} type='submit' id='search-form-submit-button'>
               <SearchIcon color='var(--elliotPrimary)' size={16} />
             </button>
           </form>


### PR DESCRIPTION
### Related Issue
https://github.com/ElliotForWater/elliotforwater.com/issues/75

## Description
Previously, users could search for a string of space chars and an error was displayed. This is because there was no validation that the query was not purely spaces.

Now, the search function does not make a request if there are only spaces in the query i.e. ' ' or '       '. Search functionality still works for queries like '        a'.

#### Impacted Areas in Application
Search experience 

#### Steps to Test or Reproduce
search for ' ' or '     '. 


#### Related PRs
n/a

------------------------------------------------
## PR Checklist:

- [x] My code follows the style guidelines of this project and I have double check my own code
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run test` and be sure all test pass
- [x] I have run `npm run build:dev` and be sure no error blovk the build
- [x] I have test locally that everything run as expected
- [x] I have properly fill in the PR template
- [x] I have ask for reviews
