### PR TITLE
Feat: Listen to message from Firefox for Add To Button

### DIFF
--- a/components/Buttons/ButtonAddToBrowser.tsx
+++ b/components/Buttons/ButtonAddToBrowser.tsx
@@ -47,6 +47,16 @@ export default function ButtonAddToBrowser() {
       if (!window.extensionInterface) {
         setBrowserName('firefox')
       }
+
+      window.addEventListener('message', function (event) {
+        if (event.data) {
+          console.log('test ff??')
+        }
+        if (event.source === window && event.data.direction && event.data.direction !== 'content-script-ff') {
+          // Assume extension is now installed
+          setBrowserName('firefox')
+        }
+      })
     }
   }, [])
 

--- a/components/Buttons/ButtonAddToBrowser.tsx
+++ b/components/Buttons/ButtonAddToBrowser.tsx
@@ -44,16 +44,10 @@ export default function ButtonAddToBrowser() {
     }
 
     if (isFirefox) {
-      if (!window.extensionInterface) {
-        setBrowserName('firefox')
-      }
-
+      // check msg from extension content-script.js
       window.addEventListener('message', function (event) {
-        if (event.data) {
-          console.log('test ff??')
-        }
-        if (event.source === window && event.data.direction && event.data.direction !== 'content-script-ff') {
-          // Assume extension is now installed
+        const { source, data } = event
+        if (source === window && data?.target === 'content-script-ff' && data?.message !== 'installed') {
           setBrowserName('firefox')
         }
       })

--- a/components/RefineSearch/RefineSearch.module.css
+++ b/components/RefineSearch/RefineSearch.module.css
@@ -7,6 +7,7 @@
   margin-bottom: 10px;
   word-break: break-word;
   overflow: hidden;
+  display: 0;
 }
 
 .title {

--- a/components/RefineSearch/RefineSearch.module.css
+++ b/components/RefineSearch/RefineSearch.module.css
@@ -7,7 +7,6 @@
   margin-bottom: 10px;
   word-break: break-word;
   overflow: hidden;
-  display: 0;
 }
 
 .title {


### PR DESCRIPTION
NOTE: To merge once the new version of FF extension is on production.


## Description
Change the method how we listen to Firefox extension message in order to know if the end-user had the extension installed or not.

#### Impacted Areas in Application
"Add to Firefox" button

#### Steps to Test or Reproduce
Open webpage in firefox and check if the button is hide/shown based on if you have the Firefox extension isnatlled.

------------------------------------------------
## PR Checklist:

- [ ] My code follows the style guidelines of this project and I have double check my own code
- [ ] I have made corresponding changes to the documentation, if any
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run test` and be sure all test pass
- [ ] I have run `npm run build:dev` and be sure no error blovk the build
- [ ] I have test locally that everything run as expected
- [ ] I have properly fill in the PR template
- [ ] I have ask for reviews
