### PR TITLE
fix: searching # returns to homepage

### DIFF
--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -110,7 +110,7 @@ const SearchBar = ({ big }: SearchProps) => {
   useEffect(() => {
     const fetchSuggestedWords = async () => {
       try {
-        const res = await fetchJsonp(`${SUGGESTED_WORDS_URL}${searchValue}`)
+        const res = await fetchJsonp(`${SUGGESTED_WORDS_URL}${encodeURIComponent(searchValue)}`)
         const suggestedWordsArray = await res.json()
         setSuggestedWords(suggestedWordsArray[1].slice(0, 10))
         return

--- a/helpers/_utils.tsx
+++ b/helpers/_utils.tsx
@@ -6,7 +6,7 @@ export function formatNumber(num) {
 export const isBrowser = () => !!(typeof window !== 'undefined' && window.document && window.document.createElement)
 
 export function queryNoWitheSpace(query: string) {
-  return query.replace(/\s/g, '+')
+  return encodeURIComponent(query).replace(/%20/g,"+")
 }
 
 export function getGeoloc() {


### PR DESCRIPTION
### Related Issue
#74 

## Description
Before, searching "#" would lead back to the homePage, and searching "&" would lead the rest of the query to disappear. The same issue was there for suggested searches as well. Now, the URL query is encoded, and leads to give the proper search results, as well as suggestions.

Search Results:
Couldn't show the search results as I wasn't able to get the API up, because of missing env keys.
Before:
<img width="407" alt="Screenshot 2021-09-03 at 9 30 43 PM" src="https://user-images.githubusercontent.com/22593204/132036115-859d5c55-31b9-462b-8a71-23ca71465e49.png">
After:
<img width="404" alt="Screenshot 2021-09-03 at 9 30 26 PM" src="https://user-images.githubusercontent.com/22593204/132036073-3f3f255a-c5fb-4e36-955a-a0c7fb174f0b.png">

Search Suggestions:
Before:
<img width="400" alt="Screenshot 2021-09-03 at 9 29 26 PM" src="https://user-images.githubusercontent.com/22593204/132034802-7e35a54c-ce34-4bfc-8664-2fbd697dcdda.png">
After:
<img width="400" alt="Screenshot 2021-09-03 at 9 29 40 PM" src="https://user-images.githubusercontent.com/22593204/132034833-a47cbca2-9e24-47e2-8124-4df5d1e33678.png">


#### Impacted Areas in Application
`searchBar.tsx` for the search suggestions, and `_utils.tsx` containing the `queryNoWitheSpace()` function.


#### Steps to Test or Reproduce
Search for something containing #, or even &.


#### Related PRs
None

------------------------------------------------
## PR Checklist:

- [x] My code follows the style guidelines of this project and I have double check my own code
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run test` and be sure all test pass
- [x] I have run `npm run build:dev` and be sure no error blovk the build
- [x] I have test locally that everything run as expected
- [x] I have properly fill in the PR template
- [x] I have ask for reviews
