### PR TITLE
Fix queryNoWitheSpace typo (issue 92)

### DIFF
--- a/components/RefineSearch/RefineSearch.tsx
+++ b/components/RefineSearch/RefineSearch.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 import useTranslation from 'next-translate/useTranslation'
 import { UserContext } from '../../context/UserContext'
 import styles from './RefineSearch.module.css'
-import { queryNoWitheSpace } from '../../helpers/_utils'
+import { queryNoWhiteSpace } from '../../helpers/_utils'
 
 type relatedObj = {
   text: string
@@ -22,7 +22,7 @@ const RefineSearch = ({ refineSearches }: Props) => {
 
   function handleClick(e, text) {
     e.preventDefault()
-    const queryNoWhite = queryNoWitheSpace(text)
+    const queryNoWhite = queryNoWhiteSpace(text)
 
     setUserState({ numOfSearches: Number(userState.numOfSearches) + 1 })
     router.push(`search?query=${queryNoWhite}&type=web`)

--- a/components/SearchBar/SearchBar.tsx
+++ b/components/SearchBar/SearchBar.tsx
@@ -8,7 +8,7 @@ import classnames from 'classnames'
 import useTranslation from 'next-translate/useTranslation'
 import styles from './SearchBar.module.css'
 import SearchIcon from '../Icons/SearchIcon'
-import { queryNoWitheSpace } from '../../helpers/_utils'
+import { queryNoWhiteSpace } from '../../helpers/_utils'
 
 type SearchProps = {
   big?: boolean
@@ -143,7 +143,7 @@ const SearchBar = ({ big }: SearchProps) => {
 
     setUserState({ numOfSearches: Number(userState.numOfSearches) + 1 })
 
-    const queryNoSpace = queryNoWitheSpace(searchString)
+    const queryNoSpace = queryNoWhiteSpace(searchString)
     router.push(`search?query=${queryNoSpace}&type=${typeValue}`)
     resetDropdown(event)
   }

--- a/helpers/_utils.tsx
+++ b/helpers/_utils.tsx
@@ -5,8 +5,8 @@ export function formatNumber(num) {
 /* Checks if in browser environment and not in SSR */
 export const isBrowser = () => !!(typeof window !== 'undefined' && window.document && window.document.createElement)
 
-export function queryNoWitheSpace(query: string) {
-  return encodeURIComponent(query).replace(/%20/g,"+")
+export function queryNoWhiteSpace(query: string) {
+  return encodeURIComponent(query).replace(/%20/g, '+')
 }
 
 export function getGeoloc() {

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -10,7 +10,7 @@ import Layout from '../components/Layout/Layout'
 import TabsMenu from '../components/TabsMenu/TabsMenu'
 import Loader from '../components/Loader/Loader'
 import LoadMore from '../components/LoadMore/LoadMore'
-import { formatNumber, queryNoWitheSpace, getClientIp } from '../helpers/_utils'
+import { formatNumber, queryNoWhiteSpace, getClientIp } from '../helpers/_utils'
 import { COOKIE_NAME_ADULT_FILTER, getCookie, convertAdultFilter } from '../helpers/_cookies'
 import { FiMoreVertical } from 'react-icons/fi'
 import { FaWikipediaW, FaYoutube, FaTwitch } from 'react-icons/fa'
@@ -123,7 +123,7 @@ function SearchPage({ query, type, errorCode, activeTab, totResults, results }) 
   const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [content, setContent] = useState(null)
-  const queryNoWhite = queryNoWitheSpace(query)
+  const queryNoWhite = queryNoWhiteSpace(query)
   const [errorStatus, setStatusCode] = useState(errorCode)
 
   const [allResults, setAllResults] = useState(results)
@@ -415,7 +415,7 @@ SearchPage.getInitialProps = async ({ req, res, query, pathname }) => {
   let userAgent
   let adultContentCookie
   let fullUrl
-  const queryNoWhite = queryNoWitheSpace(searchQuery)
+  const queryNoWhite = queryNoWhiteSpace(searchQuery)
   const oldQuery = query.q
   const isMap = type === 'map'
 


### PR DESCRIPTION
### Related Issue
#92 

## Description
Before:
const queryNoWhite = queryNoWitheSpace(query)

After:
const queryNoWhite = queryNoWhiteSpace(query): 


#### Impacted Areas in Application
None.


#### Steps to Test or Reproduce
Nothing to reproduce.


#### Related PRs
None.

------------------------------------------------
## PR Checklist:

- [x] My code follows the style guidelines of this project and I have double check my own code
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run test` and be sure all test pass
- [x] I have run `npm run build:dev` and be sure no error blovk the build
- [x] I have test locally that everything run as expected
- [x] I have properly fill in the PR template
- [x] I have ask for reviews
