### PR TITLE
Fix: Toggle menu and droplet tooltip in sync (issue 83)

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useContext } from 'react'
+import React, { FC, useState, useRef, useEffect, useContext } from 'react'
 import useTranslation from 'next-translate/useTranslation'
 import Link from 'next/link'
 import SearchBar from '../SearchBar/SearchBar'
@@ -13,14 +13,22 @@ function Droplet() {
   const { userState } = useContext(UserContext)
   const { t } = useTranslation()
   const isBreakpoint = useMediaQuery(768)
+  const dropletContainer = useRef(null)
+
+  useEffect(() => {
+    function handleClickOutside(event) {
+      const isOutsideDropletContainer = dropletContainer.current && !dropletContainer.current.contains(event.target)
+      if (isOutsideDropletContainer) setHideTooltip(true)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [dropletContainer])
 
   return (
-    <div
-      className={styles.dropletContainer}
-      onMouseEnter={() => setHideTooltip(false)}
-      onMouseLeave={() => setHideTooltip(true)}
-      onClick={() => setHideTooltip((prev) => !prev)}
-    >
+    <div className={styles.dropletContainer} ref={dropletContainer} onClick={() => setHideTooltip(!hideTooltip)}>
       <img className={styles.dropletImg} src='/images/water_droplet.svg' />
       <Tooltip isHidden={hideTooltip} direction={isBreakpoint ? 'left' : 'right'}>
         {t('common:header.tooltip_count')}

--- a/components/HeaderHome/HeaderHome.tsx
+++ b/components/HeaderHome/HeaderHome.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useContext } from 'react'
+import React, { FC, useState, useContext, useRef, useEffect } from 'react'
 import { UserContext } from '../../context/UserContext'
 import useTranslation from 'next-translate/useTranslation'
 import Nav from '../Nav/Nav'
@@ -9,17 +9,25 @@ const HeaderHome: FC = () => {
   const { t } = useTranslation()
   const [hideTooltip, setHideTooltip] = useState(true)
   const { userState } = useContext(UserContext)
+  const dropletContainer = useRef(null)
+
+  useEffect(() => {
+    function handleClickOutside(event) {
+      const isOutsideDropletContainer = dropletContainer.current && !dropletContainer.current.contains(event.target)
+      if (isOutsideDropletContainer) setHideTooltip(true)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [dropletContainer])
 
   return (
     <header className={styles.header}>
       <div className={styles.headerRight}>
         <div className={styles.rightSide}>
-          <div
-            className={styles.dropletContainer}
-            onMouseEnter={() => setHideTooltip(false)}
-            onMouseLeave={() => setHideTooltip(true)}
-            onClick={() => setHideTooltip((prev) => !prev)}
-          >
+          <div className={styles.dropletContainer} ref={dropletContainer} onClick={() => setHideTooltip(!hideTooltip)}>
             <img className={styles.dropletImg} src='/images/water_droplet.svg' />
             <Tooltip isHidden={hideTooltip} direction='right'>
               {t('common:header.tooltip_count')}


### PR DESCRIPTION
### Related Issue
#83 

## Description
- removes the mouse-enter/mouse-leave triggers
- adds useEffect to keep track of droplet tooltip visibility

- the tooltip now acts like the hamburger menu


#### Impacted Areas in Application
- any page with Header
- any page with HeaderHome


#### Steps to Test or Reproduce
- click on tooltip. 
   = tooltip text should appear
- click outside tooltip (this includes clicking on the menu).
   = tooltip text should disappear


#### Related PRs
#87 

------------------------------------------------
## PR Checklist:

- [x] My code follows the style guidelines of this project and I have double check my own code
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run test` and be sure all test pass
- [x] I have run `npm run build:dev` and be sure no error blovk the build
- [x] I have test locally that everything run as expected
- [x] I have properly fill in the PR template
- [x] I have ask for reviews
