### PR TITLE
Conditionally show CTA buttons based on device type

### DIFF
--- a/src/components/common/AddToBrowserCTA.vue
+++ b/src/components/common/AddToBrowserCTA.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { computed, ref, onMounted } from 'vue';
+import AddToChromeButton from '@/components/ui/AddToChromeButton.vue';
+import AddToFirefoxButton from '@/components/ui/AddToFirefoxButton.vue';
+import Button from '@/components/ui/Button.vue';
+
+const props = withDefaults(
+  defineProps<{
+    showFreeBadge?: boolean;
+    userAgent?: string; // for testing if true, show AddTo button even on mobile/tablet */
+    ctaLink: string;
+    label: string;
+  }>(),
+  {
+    showFreeBadge: true,
+    userAgent: undefined,
+  },
+);
+
+const userAgent = computed(() => (props.userAgent ?? navigator.userAgent).toLowerCase());
+const isFirefox = computed(() => userAgent.value.includes('firefox'));
+const isMobileOrTablet = ref(false);
+
+onMounted(() => {
+  const hasTouch = navigator.maxTouchPoints > 0 || 'ontouchstart' in window;
+  const isMobileUserAgent = /android|iphone|ipad|ipod|mobile|tablet/.test(userAgent.value);
+  isMobileOrTablet.value = hasTouch && isMobileUserAgent;
+});
+
+const submit = (event?: Event) => {
+  event?.preventDefault();
+  const params = new URLSearchParams({
+    redirect_to: 'https://elliotforwater.com/',
+  });
+
+  window.open(`${props.ctaLink}?${params.toString()}`, '_blank');
+};
+</script>
+
+<template>
+  <!-- Mobile/Tablet -->
+  <div v-if="isMobileOrTablet" class="w-full">
+    <slot name="mobileHint" />
+    <div class="flex justify-center pt-1 mt-2">
+      <Button variant="secondary" class="text-sm sm:text-base" @click="submit">
+        {{ props.label }}
+      </Button>
+    </div>
+    <div class="flex justify-center pt-1 mt-2">
+      <slot name="secondCta" />
+    </div>
+  </div>
+
+  <!-- Desktop View -->
+  <div v-else class="flex items-start gap-2 md:gap-6 justify-center">
+    <div class="relative">
+      <AddToChromeButton v-if="!isFirefox" />
+      <AddToFirefoxButton v-else />
+
+      <div v-if="showFreeBadge" class="max-w-[70px] md:max-w-[100px] lg:max-w-[172px] w-full -translate-x-[40%] sm:-translate-x-[98%] sm:-translate-y-[2%]">
+        <img src="/icons/free-icon.svg" alt="free-icon" />
+      </div>
+    </div>
+    <slot name="secondCta" />
+  </div>
+</template>

--- a/src/components/common/AddToBrowserCTA.vue
+++ b/src/components/common/AddToBrowserCTA.vue
@@ -41,12 +41,11 @@ const submit = (event?: Event) => {
   <!-- Mobile/Tablet -->
   <div v-if="isMobileOrTablet" class="w-full">
     <slot name="mobileHint" />
-    <div class="flex justify-center pt-1 mt-2">
+    <div class="flex items-start gap-2 md:gap-6 justify-center">
       <Button variant="secondary" class="text-sm sm:text-base" @click="submit">
         {{ props.label }}
       </Button>
-    </div>
-    <div class="flex justify-center pt-1 mt-2">
+
       <slot name="secondCta" />
     </div>
   </div>

--- a/src/components/common/Navbar.vue
+++ b/src/components/common/Navbar.vue
@@ -2,8 +2,7 @@
 import { ref, watch, onUnmounted } from 'vue';
 import { RouterLink } from 'vue-router';
 import Button from '../ui/Button.vue';
-import AddToChromeButton from '../ui/AddToChromeButton.vue';
-import AddToFirefoxButton from '../ui/AddToFirefoxButton.vue';
+import AddToBrowserCTA from './AddToBrowserCTA.vue';
 
 // navigation links
 const navLinks = [
@@ -50,10 +49,6 @@ const scrollToSection = (hash: string) => {
     }
   }
 };
-
-let userAgent = navigator.userAgent;
-// let isChrome = userAgent.includes('Chrome') && !userAgent.includes('OPR');
-let isFirefox = userAgent.includes('Firefox');
 </script>
 
 <template>
@@ -85,8 +80,8 @@ let isFirefox = userAgent.includes('Firefox');
 
     <!-- Right Side Buttons -->
     <div class="flex gap-2 shrink-0 relative z-50">
-      <AddToChromeButton v-if="!isFirefox" />
-      <AddToFirefoxButton v-if="isFirefox" />
+      <AddToBrowserCTA :showFreeBadge="false" ctaLink="https://magic.beehiiv.com/v1/e9406cdd-094c-4ff2-a866-49b0aa2dd605" label="Send me the link" />
+
       <!-- Hamburger (Mobile only) -->
       <Button variant="primary" class="block lg:hidden !rounded-2xl" @click="toggleMenu">
         <span v-if="!isMenuOpen">☰</span>

--- a/src/components/sections/home/hero.vue
+++ b/src/components/sections/home/hero.vue
@@ -28,11 +28,11 @@ import AddToBrowserCTA from '@/components/common/AddToBrowserCTA.vue';
 
         <AddToBrowserCTA ctaLink="https://magic.beehiiv.com/v1/e9406cdd-094c-4ff2-a866-49b0aa2dd605" label="Send me the link">
           <template #mobileHint>
-            <div class="text-base text-center text-text-body">Elliot for Water is only available on desktop, leave your email, and we’ll send you the download link.</div>
+            <div class="text-base text-center text-text-body pb-1 mb-2">Elliot for Water is only available on desktop, leave your email, and we’ll send you the download link.</div>
           </template>
 
           <template #secondCta>
-            <Button variant="primary" href="#how_it_works">Discover more</Button>
+            <Button variant="primary" class="text-sm sm:text-base" href="#how_it_works">Discover more</Button>
           </template>
         </AddToBrowserCTA>
       </div>

--- a/src/components/sections/home/hero.vue
+++ b/src/components/sections/home/hero.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
-import AddToChromeButton from '@/components/ui/AddToChromeButton.vue';
-import AddToFirefoxButton from '@/components/ui/AddToFirefoxButton.vue';
 import Button from '@/components/ui/Button.vue';
-
-let userAgent = navigator.userAgent;
-// let isChrome = userAgent.includes('Chrome') && !userAgent.includes('OPR');
-let isFirefox = userAgent.includes('Firefox');
+import AddToBrowserCTA from '@/components/common/AddToBrowserCTA.vue';
 </script>
 
 <template>
@@ -31,16 +26,15 @@ let isFirefox = userAgent.includes('Firefox');
           Elliot for Water is a free productivity dashboard that helps you stay focused while supporting clean water projects around the world.
         </p>
 
-        <div class="flex items-start gap-2 md:gap-6 justify-center">
-          <div class="relative">
-            <AddToChromeButton v-if="!isFirefox" />
-            <AddToFirefoxButton v-if="isFirefox" />
-            <div class="max-w-[70px] md:max-w-[100px] lg:max-w-[172px] w-full -translate-x-[40%] sm:-translate-x-[98%] sm:-translate-y-[2%]">
-              <img src="/icons/free-icon.svg" alt="free-icon" />
-            </div>
-          </div>
-          <Button variant="primary" href="#how_it_works"> Discover more </Button>
-        </div>
+        <AddToBrowserCTA ctaLink="https://magic.beehiiv.com/v1/e9406cdd-094c-4ff2-a866-49b0aa2dd605" label="Send me the link">
+          <template #mobileHint>
+            <div class="text-base text-center text-text-body">Elliot for Water is only available on desktop, leave your email, and we’ll send you the download link.</div>
+          </template>
+
+          <template #secondCta>
+            <Button variant="primary" href="#how_it_works">Discover more</Button>
+          </template>
+        </AddToBrowserCTA>
       </div>
 
       <div class="w-full">

--- a/src/components/sections/home/impact.vue
+++ b/src/components/sections/home/impact.vue
@@ -23,7 +23,9 @@ import SectionTitle from '@/components/ui/SectionTitle.vue';
       <div class="flex flex-col items-center gap-6 pt-6">
         <AddToBrowserCTA :showFreeBadge="false" ctaLink="https://magic.beehiiv.com/v1/e9406cdd-094c-4ff2-a866-49b0aa2dd605" label="Send me the link">
           <template #mobileHint>
-            <div class="text-text-body text-sm md:text-base font-medium text-center">Elliot for Water is only available on desktop, leave your email, and we’ll send you the download link.</div>
+            <div class="text-text-body text-sm md:text-base font-medium text-center pb-1 mb-2">
+              Elliot for Water is only available on desktop, leave your email, and we’ll send you the download link.
+            </div>
           </template>
         </AddToBrowserCTA>
       </div>

--- a/src/components/sections/home/impact.vue
+++ b/src/components/sections/home/impact.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
-import AddToChromeButton from '@/components/ui/AddToChromeButton.vue';
-import AddToFirefoxButton from '@/components/ui/AddToFirefoxButton.vue';
+import AddToBrowserCTA from '@/components/common/AddToBrowserCTA.vue';
 import CardDetails from '@/components/ui/card/CardDetails.vue';
 import SectionTitle from '@/components/ui/SectionTitle.vue';
-
-let userAgent = navigator.userAgent;
-// let isChrome = userAgent.includes('Chrome') && !userAgent.includes('OPR');
-let isFirefox = userAgent.includes('Firefox');
 </script>
 
 <template>
@@ -26,16 +21,11 @@ let isFirefox = userAgent.includes('Firefox');
         </CardDetails>
       </div>
       <div class="flex flex-col items-center gap-6 pt-6">
-        <AddToChromeButton v-if="!isFirefox" />
-        <AddToFirefoxButton v-if="isFirefox" />
-        <div class="flex items-center flex-wrap gap-2 md:gap-4 px-[2%]">
-          <p class="uppercase text-neutral-400 text-xs md:text-sm">Available for Chrome & Firefox</p>
-          <div class="flex items-center gap-2 md:gap-3">
-            <img src="/logos/chrome-logo.svg" alt="chrome-icon" class="size-4 sm:size-5" />
-            <img src="/logos/firefox-logo.svg" alt="chrome-icon" class="size-4 sm:size-5" />
-            <!-- <img src="/logos/edge-logo.svg" alt="chrome-icon" class="size-4 sm:size-5" /> -->
-          </div>
-        </div>
+        <AddToBrowserCTA :showFreeBadge="false" ctaLink="https://magic.beehiiv.com/v1/e9406cdd-094c-4ff2-a866-49b0aa2dd605" label="Send me the link">
+          <template #mobileHint>
+            <div class="text-text-body text-sm md:text-base font-medium text-center">Elliot for Water is only available on desktop, leave your email, and we’ll send you the download link.</div>
+          </template>
+        </AddToBrowserCTA>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Move "Add To" logic to a common component AddToBrowserCTA
- Use this component in Nav, Hero, Impact section 
- AddToBrowser accept data like: button label, button link, additional template so it can be modified based on where it is called from. 

After - Mobile:
<img width="1290" height="16384" alt="2-elliot_mobile-screenshot" src="https://github.com/user-attachments/assets/fbc49568-28a4-4205-af2a-0805408fbec2" />

After - Dekstop:
<img width="1065" height="813" alt="Screenshot from 2026-02-10 16-54-24" src="https://github.com/user-attachments/assets/a386ef78-484a-439f-977a-b94b6044aefd" />
<img width="1065" height="813" alt="Screenshot from 2026-02-10 16-54-12" src="https://github.com/user-attachments/assets/f5d4560a-c3a0-4fa5-8350-c9b1f51f720c" />

CTA Link end up to: 
<img width="1065" height="813" alt="Screenshot from 2026-02-10 16-54-40" src="https://github.com/user-attachments/assets/2aa18e1b-0a92-4978-b395-68464f1225be" />
